### PR TITLE
Update audiopiracyguide.md   add PodExtra AI to Podcast Streaming

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -224,6 +224,7 @@
 * [ListenBox](https://listenbox.app/) or [PodSync](https://github.com/mxpv/podsync) - Turn YouTube Video into Podcasts
 * [JRE Missing](https://www.jremissing.com/) - Tracks Missing JRE Podcasts
 * [Podcatalysts](https://podcatalysts.substack.com/) - Podcast Recommendation Newsletter
+* [PodExtra AI](https://www.podextra.ai/) - AI Podcast assistant with transcript and mindmap
 
 ***
 


### PR DESCRIPTION
add PodExtra AI to Podcast Streaming.  PodExtra is an innovative AI-powered podcast tool that provides transcripts, summaries, mind maps, outlines, highlights, and takeaways for your favorite podcasts. It allows you to quickly browse through the content, saving time and improving efficiency.